### PR TITLE
Fixes and Pagination

### DIFF
--- a/codenation/codenation/settings.py
+++ b/codenation/codenation/settings.py
@@ -133,3 +133,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Django Rest Framework Configuration
+
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'codenation.utils.pagination.BasicPagination',
+    'PAGE_SIZE': 50,
+}

--- a/codenation/codenation/utils/pagination.py
+++ b/codenation/codenation/utils/pagination.py
@@ -1,0 +1,25 @@
+from rest_framework.settings import api_settings
+from rest_framework.response import Response
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.exceptions import NotAcceptable
+
+
+class BasicPagination(PageNumberPagination):
+    def get_paginated_response(self, queryset, request, serializer,
+                            serializer_kwargs={}):
+        self.page_size = self.__get_page_size_from_request(request)
+
+        serializer = serializer(
+            self.paginate_queryset(queryset, request),
+            many=True,
+            **serializer_kwargs
+        )
+        return super().get_paginated_response(serializer.data)
+    
+    def __get_page_size_from_request(self, request):
+        page_size = request.query_params.get('page_size')
+        
+        if page_size and not page_size.isnumeric():
+            raise NotAcceptable(detail=f'"page_size" must be integer.')
+        
+        return page_size or api_settings.PAGE_SIZE

--- a/codenation/loans/views.py
+++ b/codenation/loans/views.py
@@ -10,6 +10,7 @@ from django.db.models import Sum
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
@@ -24,13 +25,15 @@ class LoanAPI(APIView):
         },
     )
     def get(self, request, format=None):
-        loans = Loan.objects.all()
-        serializer = LoanDetailSerializer(
-            loans,
-            fields=('loan_id', 'amount', 'term',),
-            many=True
+        paginator = api_settings.DEFAULT_PAGINATION_CLASS()
+        return paginator.get_paginated_response(
+            queryset=Loan.objects.all(),
+            request=request,
+            serializer=LoanDetailSerializer,
+            serializer_kwargs={
+                'fields': ('loan_id', 'amount', 'term',)
+            }
         )
-        return Response(serializer.data)
     
     @swagger_auto_schema(
         request_body=LoanSerializer(),

--- a/codenation/loans/views.py
+++ b/codenation/loans/views.py
@@ -20,8 +20,28 @@ class LoanAPI(APIView):
         security=[],
         operation_description='Retrive all existing loans',
         operation_id='GET /loans',
+        manual_parameters=[
+            openapi.Parameter(name='page', in_=openapi.IN_QUERY, default=1,
+                type=openapi.TYPE_INTEGER, description='Page number'),
+            openapi.Parameter(name='page_size', in_=openapi.IN_QUERY, default=50,
+                type=openapi.TYPE_INTEGER, description='Number of page elements'),
+        ],
         responses={
-            200: LoanDetailSerializer(fields=('loan_id', 'amount', 'term',), many=True)
+            status.HTTP_200_OK: openapi.Response(
+                description='Loans list',
+                examples={
+                    'application/json': {
+                        'count': openapi.TYPE_INTEGER,
+                        'next': openapi.TYPE_STRING,
+                        'previous': openapi.TYPE_STRING,
+                        'results': [{
+                            'loan_id': openapi.FORMAT_UUID,
+                            'amount': openapi.TYPE_NUMBER,
+                            'term': openapi.TYPE_INTEGER,
+                        }]
+                    }
+                }
+            )
         },
     )
     def get(self, request, format=None):
@@ -41,21 +61,24 @@ class LoanAPI(APIView):
         operation_description='Create a loan',
         operation_id='POST /loans',
         responses={
-            201: openapi.Response(
+            status.HTTP_201_CREATED: openapi.Response(
                     description='Loan has been created',
                     examples={
-                        'created': json.dumps({
-                            'id': openapi.TYPE_STRING,
+                        'application/json': {
+                            'id': openapi.FORMAT_UUID,
                             'installment': openapi.TYPE_NUMBER
-                            }
-                        )
+                        }
                     }
                 ),
-            400: openapi.Response(
+            status.HTTP_400_BAD_REQUEST: openapi.Response(
                 description='Fields are invalid',
                 examples={
-                    'field_required': json.dumps([{'field': 'This field is required'}]),
-                    'field_wrong': json.dumps([{'field': 'Reason of the error'}])
+                    'application/json_required': [{
+                        'field': 'This field is required'
+                    }],
+                    'application/json_wrong': [{
+                        'field': 'Reason of the error'
+                    }]
                 }
             )
         }
@@ -79,11 +102,11 @@ class LoanDetailAPI(APIView):
         operation_description='Retrive loan with its details',
         operation_id='GET /loans/{loan_id}',
         responses={
-            200: LoanDetailSerializer(),
-            404: openapi.Response(
+            status.HTTP_200_OK: LoanDetailSerializer(),
+            status.HTTP_404_NOT_FOUND: openapi.Response(
                 description='Loan not found',
                 examples={
-                    'not_found': json.dumps({'detail': 'Not Found.'})
+                    'application/json': {'detail': 'Not Found.'}
                 }
             )
         }
@@ -134,7 +157,7 @@ class LoanPaymentApi(APIView):
         operation_description='Retrive payments from a especific loan',
         operation_id='GET /loans/{loan_id}/payments',
         responses={
-            200: LoanPaymentDetailSerializer(many=True)
+            status.HTTP_200_OK: LoanPaymentDetailSerializer(many=True)
         }
     )
     def get(self, request, loan_id, format=None):
@@ -142,16 +165,21 @@ class LoanPaymentApi(APIView):
         return Response(LoanPaymentDetailSerializer(loan_payments, many=True).data)
 
     @swagger_auto_schema(
+        request_body=LoanPaymentSerializer(),
         security=[],
         operation_description='Crete Loan Payment',
-        operation_id='POST /loans/{loan_id}',
+        operation_id='POST /loans/{loan_id}/payments',
         responses={
-            201: LoanPaymentDetailSerializer(),
-            400: openapi.Response(
+            status.HTTP_201_CREATED: LoanPaymentDetailSerializer(),
+            status.HTTP_400_BAD_REQUEST: openapi.Response(
                 description='Fields are invalid',
                 examples={
-                    'field_required': json.dumps([{'field': 'This field is required'}]),
-                    'field_wrong': json.dumps([{'field': 'Reason of the error'}])
+                    'application/json_required': [{
+                        'field_name': 'This field is required'
+                    }],
+                    'application/json_wrong': [{
+                        'field_name': 'Reason of the error'
+                    }]
                 }
             )
         }
@@ -189,16 +217,20 @@ class LoanPaymentBalanceApi(APIView):
         operation_id='POST /loans/{loan_id}/balance',
         request_body=LoanPaymentBalanceSerializer(),
         responses={
-            201: openapi.Response(
+            status.HTTP_201_CREATED: openapi.Response(
                 description='Loan Payments\' balance',
                 examples={
-                    'balance': json.dumps({'balance': openapi.TYPE_NUMBER})
+                    'application/json_balance': {
+                        'balance': openapi.TYPE_NUMBER
+                    }
                 }
             ),
-            404: openapi.Response(
+            status.HTTP_404_NOT_FOUND: openapi.Response(
                 description='Loan not found',
                 examples={
-                    'not_found': json.dumps({'detail': 'Not Found.'})
+                    'application/json_not_found': {
+                        'detail': 'Not Found.'
+                    }
                 }
             )
         }

--- a/project_helpers/generate_data/generate_data.py
+++ b/project_helpers/generate_data/generate_data.py
@@ -49,7 +49,7 @@ def generate_loans(number_of_loans):
 def generate_loans_payments(loans):
     loan_payments = []
     for loan in loans:
-        number_of_payments = randrange(1, loan.fields['amount_of_payments'])
+        number_of_payments = randrange(0, loan.fields['amount_of_payments'])
         for payment_number in range(1, number_of_payments + 1):
             loan_payment = LoanPayment(
                 pk=str(uuid4()),


### PR DESCRIPTION
Fix inside `project_helpers/generate_data/generate_data.py`, when randrange receive as arguments two equal numbers, it raise an Exception. I changed the firsto argument to 0(zero), because we won't have a Loan with term less than 1(one).

Additionally, I created a basic class for pagination and I applied this pagination to Loans List Endpoint, `(GET) /loans`, we can pass two query parameters:
* `page`: Actual page number
* `page_size`: Number of elements per page

The documentation has some errors, I fix them.